### PR TITLE
Generate placeholder tests alongside models

### DIFF
--- a/.github/workflows/sbml_test_suite.yml
+++ b/.github/workflows/sbml_test_suite.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true

--- a/.github/workflows/sbml_test_suite.yml
+++ b/.github/workflows/sbml_test_suite.yml
@@ -35,6 +35,16 @@ jobs:
             last_case: "1821"
 
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -108,7 +118,7 @@ jobs:
           repo="deb [signed-by=/usr/share/keyrings/chaste.asc] https://chaste.github.io/ubuntu ${codename}/"
           echo "${repo}" | sudo tee /etc/apt/sources.list.d/chaste.list
           sudo apt-get update
-          sudo apt-get install -y chaste-dependencies lcov
+          sudo apt-get install -y chaste-dependencies
 
       - name: Setup Chaste paths
         run: |
@@ -117,7 +127,7 @@ jobs:
 
       - name: Configure Chaste
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Debug -DChaste_ERROR_ON_WARNING=OFF -DChaste_COVERAGE=ON ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DChaste_ERROR_ON_WARNING=OFF -DChaste_COVERAGE=OFF ..
         working-directory: Chaste/build
 
       - name: Build SbmlRefModels

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ chaste-sbml generate my_model.xml --model-type srn --output-dir src/
 ```
 usage: chaste-sbml generate [-h] [--output-dir OUTPUT_DIR]
                                     [--model-type [{generic,srn,cell-cycle}]]
+                                    [--tests | --no-tests]
+                                    [--test-output-dir TEST_OUTPUT_DIR]
                                     sbml_file
 
 positional arguments:
@@ -97,7 +99,16 @@ options:
                         The directory to place output files in
   --model-type [{generic,srn,cell-cycle}]
                         The type of model to generate
+  --tests, --no-tests   Generate placeholder test files (default: on)
+  --test-output-dir TEST_OUTPUT_DIR
+                        The directory to place generated test files in
+                        (defaults to --output-dir)
 ```
+
+By default `generate` also emits a placeholder test (`Test<Model>Sbml.hpp`), a
+CxxTest skeleton with a suite for the ODE system, and the SRN/cell-cycle
+model where applicable. Pass `--no-tests` to skip it, or `--test-output-dir` to
+place the placeholder test somewhere other than `--output-dir`.
 
 ### `copy-base-classes`
 

--- a/chaste_sbml/SbmlRefModels/CMakeLists.txt
+++ b/chaste_sbml/SbmlRefModels/CMakeLists.txt
@@ -1,10 +1,2 @@
 find_package(Chaste COMPONENTS cell_based)
 chaste_do_project(SbmlRefModels)
-
-# Precompile the heavy header every generated case model includes, to speed up rebuilds. The
-# serialization export wrappers are deliberately excluded (they are order-sensitive and belong in
-# each .cpp, not a shared PCH).
-if (TARGET chaste_project_SbmlRefModels)
-    target_precompile_headers(chaste_project_SbmlRefModels PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/AbstractSbmlOdeSystem.hpp")
-endif()

--- a/chaste_sbml/SbmlRefModels/generate_cases.py
+++ b/chaste_sbml/SbmlRefModels/generate_cases.py
@@ -62,7 +62,8 @@ class ChasteSbmlTestSuiteModel(ChasteSbmlModel):
 
         model_name = f"{prefix}{test_params['case']}{sbml_version.upper()}Sbml"
 
-        super().__init__(sbml_file, model_name=model_name, model_type=ModelType.GENERIC, **kwargs)
+        # This generates its own test, so disable the placeholder test
+        super().__init__(sbml_file, model_name=model_name, model_type=ModelType.GENERIC, generate_tests=False, **kwargs)
 
         self._test_type = test_type
         self._test_hpp_filename = f"Test{self._model_name}.hpp"

--- a/chaste_sbml/SbmlRefModels/test/CMakeLists.txt
+++ b/chaste_sbml/SbmlRefModels/test/CMakeLists.txt
@@ -1,15 +1,1 @@
 chaste_do_test_project(SbmlRefModels)
-
-# Precompile the heavy Chaste headers shared by every generated case test (the CVODE solver and
-# test helpers), to speed up rebuilds. FakePetscSetup and the per-test model header are left out.
-get_property(_sbml_test_targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
-foreach(_sbml_test_target ${_sbml_test_targets})
-    get_target_property(_sbml_test_type ${_sbml_test_target} TYPE)
-    if (_sbml_test_type STREQUAL "EXECUTABLE")
-        target_precompile_headers(${_sbml_test_target} PRIVATE
-            <cxxtest/TestSuite.h>
-            <CvodeAdaptor.hpp>
-            <OdeSolution.hpp>
-            <SbmlTestHelpers.hpp>)
-    endif()
-endforeach()

--- a/chaste_sbml/__main__.py
+++ b/chaste_sbml/__main__.py
@@ -34,6 +34,17 @@ def parse_args() -> argparse.Namespace:
         const="generic",
         nargs="?",
     )
+    generate.add_argument(
+        "--tests",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Generate placeholder test files (default: on). Use --no-tests to disable.",
+    )
+    generate.add_argument(
+        "--test-output-dir",
+        default=None,
+        help="The directory to place generated test files in (defaults to --output-dir)",
+    )
 
     # copy-base-classes: copy the C++ base classes the generated code depends on.
     copy_parser = subparsers.add_parser(
@@ -61,8 +72,8 @@ def process_command_line(args: "argparse.Namespace"):
     elif args.model_type == "cell-cycle":
         model_type = ModelType.CELL_CYCLE
 
-    chaste_model = ChasteSbmlModel(args.sbml_file, model_type=model_type)
-    chaste_model.write(args.output_dir)
+    chaste_model = ChasteSbmlModel(args.sbml_file, model_type=model_type, generate_tests=args.tests)
+    chaste_model.write(args.output_dir, args.test_output_dir)
 
 
 def main():

--- a/chaste_sbml/_rendering.py
+++ b/chaste_sbml/_rendering.py
@@ -21,6 +21,7 @@ from ._config import (
     DerivedQuantityKind,
     EquationType,
     EventType,
+    ModelType,
     VarType,
 )
 
@@ -39,6 +40,7 @@ class CodeRenderer:
     _env.globals["DerivedQuantityKind"] = DerivedQuantityKind
     _env.globals["EquationType"] = EquationType
     _env.globals["EventType"] = EventType
+    _env.globals["ModelType"] = ModelType
     _env.globals["PREFIX_SEP"] = PREFIX_SEP
     _env.globals["VarType"] = VarType
 

--- a/chaste_sbml/chaste_sbml_model.py
+++ b/chaste_sbml/chaste_sbml_model.py
@@ -24,12 +24,19 @@ class ChasteSbmlModel:
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, sbml_file: str, model_name: str = "", model_type: ModelType = ModelType.GENERIC) -> None:
+    def __init__(
+        self,
+        sbml_file: str,
+        model_name: str = "",
+        model_type: ModelType = ModelType.GENERIC,
+        generate_tests: bool = True,
+    ) -> None:
         """Initialise the ChasteSbmlModel.
 
         :param sbml_file: The SBML file to generate code from.
         :param model_name: The model name; derived from the filename when not given.
         :param model_type: The model type e.g. ModelType.SRN.
+        :param generate_tests: Whether to generate a placeholder test for the model.
         """
         self._sbml_file = os.path.abspath(sbml_file)
         if not os.path.isfile(self._sbml_file):
@@ -43,6 +50,9 @@ class ChasteSbmlModel:
             self._model_name = model_name[0].upper() + model_name[1:]
 
         self._model_type = model_type
+
+        self._generate_tests = generate_tests
+        self._test_hpp_filename = f"Test{self._model_name}.hpp"
 
         self._ode_class_name = self._model_name + "OdeSystem"
         self._ode_hpp_filename = f"{self._ode_class_name}.hpp"
@@ -72,6 +82,7 @@ class ChasteSbmlModel:
         self._template_vars = {}  # type: dict[str, Any]
 
         self._outputs = {}  # { filename: code }
+        self._test_outputs = {}  # { filename: code } for generated placeholder tests
         self._renderer = CodeRenderer()
 
         self._names.resolve_real_id_conflicts()
@@ -88,16 +99,32 @@ class ChasteSbmlModel:
         """
         return dict(self._outputs)
 
-    def write(self, output_directory=None):
+    @property
+    def test_outputs(self) -> dict[str, str]:
+        """Get the generated placeholder test outputs.
+
+        :return: A copy of the filename to code mapping, so callers cannot mutate the internal state.
+        """
+        return dict(self._test_outputs)
+
+    def write(self, output_directory=None, test_output_directory=None):
         """Generate Chaste code and write to file.
 
-        :param output_directory: The output directory. Defaults to the current directory.
+        :param output_directory: The output directory for the model code.
+            Defaults to the current directory.
+        :param test_output_directory: The output directory for the generated
+            placeholder tests. Defaults to ``output_directory``.
         """
         # Generate the code
         self._generate_outputs()
 
-        # Write the code to file (formatted with clang-format)
+        # Write the model code to file (formatted with clang-format)
         self._renderer.write(self._outputs, output_directory)
+
+        # Write the placeholder tests, defaulting to the model output directory
+        if self._test_outputs:
+            test_dir = test_output_directory if test_output_directory is not None else output_directory
+            self._renderer.write(self._test_outputs, test_dir)
 
     def _add_output(self, filename: str, code: str) -> None:
         """Add generated code to the outputs dictionary.
@@ -118,6 +145,14 @@ class ChasteSbmlModel:
         code = self._renderer.render(template_path, self._template_vars)
         self._add_output(filename, code)
 
+    def _generate_test_output(self) -> None:
+        """Generate the placeholder test file for the model.
+
+        Rendered into the separate test outputs so it can be written to its own directory.
+        """
+        code = self._renderer.render("test/test.hpp", self._template_vars)
+        self._test_outputs[self._test_hpp_filename] = code
+
     def _generate_outputs(self) -> None:
         """Generate Chaste code for the model."""
         # Generate code for the OdeSystem
@@ -133,6 +168,10 @@ class ChasteSbmlModel:
             self._generate_output("cell_cycle/cell_cycle.hpp", self._cell_cycle_hpp_filename)
             self._generate_output("cell_cycle/cell_cycle.cpp", self._cell_cycle_cpp_filename)
 
+        # Generate a placeholder test skeleton for the model
+        if self._generate_tests:
+            self._generate_test_output()
+
     def _populate_template_vars(self) -> None:
         """Populate the template variables for generating C++ code."""
         template_vars: dict[str, "Any"] = dict(
@@ -140,6 +179,8 @@ class ChasteSbmlModel:
             ode_class_name=self._ode_class_name,
             ode_header_guard=generate_header_guard(self._ode_hpp_filename),
             ode_hpp_file=self._ode_hpp_filename,
+            test_header_guard=generate_header_guard(self._test_hpp_filename),
+            model_type=self._model_type,
         )
 
         if self._model_type == ModelType.SRN:

--- a/chaste_sbml/templates/test/test.hpp
+++ b/chaste_sbml/templates/test/test.hpp
@@ -14,6 +14,9 @@
 #include "{{ cell_cycle_hpp_file }}"
 {% endif %}
 
+// This test is never run in parallel
+#include "FakePetscSetup.hpp"
+
 class Test{{ ode_class_name }} : public CxxTest::TestSuite
 {
     // TODO: Add tests

--- a/chaste_sbml/templates/test/test.hpp
+++ b/chaste_sbml/templates/test/test.hpp
@@ -1,0 +1,50 @@
+#ifndef {{ test_header_guard }}
+#define {{ test_header_guard }}
+
+#include <cxxtest/TestSuite.h>
+{% if model_type == ModelType.SRN or model_type == ModelType.CELL_CYCLE %}
+
+#include "AbstractCellBasedTestSuite.hpp"
+{% endif %}
+
+#include "{{ ode_hpp_file }}"
+{% if model_type == ModelType.SRN %}
+#include "{{ srn_hpp_file }}"
+{% elif model_type == ModelType.CELL_CYCLE %}
+#include "{{ cell_cycle_hpp_file }}"
+{% endif %}
+
+class Test{{ ode_class_name }} : public CxxTest::TestSuite
+{
+    // TODO: Add tests
+public:
+    void TestOdeSystem()
+    {
+        TS_ASSERT_THROWS_NOTHING({{ ode_class_name }} ode_system);
+    }
+};
+{% if model_type == ModelType.SRN %}
+
+class Test{{ srn_class_name }} : public AbstractCellBasedTestSuite
+{
+    // TODO: Add tests
+public:
+    void TestSrnModel()
+    {
+        TS_ASSERT_THROWS_NOTHING({{ srn_class_name }} srn_model);
+    }
+};
+{% elif model_type == ModelType.CELL_CYCLE %}
+
+class Test{{ cell_cycle_class_name }} : public AbstractCellBasedTestSuite
+{
+    // TODO: Add tests
+public:
+    void TestCellCycleModel()
+    {
+        TS_ASSERT_THROWS_NOTHING({{ cell_cycle_class_name }} cell_cycle_model);
+    }
+};
+{% endif %}
+
+#endif // {{ test_header_guard }}

--- a/chaste_sbml/tests/test_console.py
+++ b/chaste_sbml/tests/test_console.py
@@ -4,8 +4,11 @@ import logging
 import subprocess
 
 from chaste_sbml import __version__
+from chaste_sbml._config import ROOT_DIR
 
 logger = logging.getLogger(__name__)
+
+GOLDBETER = ROOT_DIR / "SbmlRefModels" / "src" / "reference" / "Goldbeter1991" / "Goldbeter1991.xml"
 
 
 def test_help():
@@ -61,3 +64,56 @@ def test_copy_base_classes_accepts_output_dir(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert (tmp_path / "AbstractSbmlOdeSystem.hpp").is_file()
+
+
+def test_generate_emits_placeholder_test(tmp_path):
+    """generate produces a placeholder test file alongside the model by default."""
+    result = subprocess.run(
+        ["chaste-sbml", "generate", str(GOLDBETER), "--output-dir", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "Goldbeter1991SbmlOdeSystem.hpp").is_file()
+    assert (tmp_path / "TestGoldbeter1991Sbml.hpp").is_file()
+
+
+def test_generate_no_tests_skips_placeholder_test(tmp_path):
+    """generate --no-tests writes the model but no placeholder test."""
+    result = subprocess.run(
+        ["chaste-sbml", "generate", str(GOLDBETER), "--output-dir", str(tmp_path), "--no-tests"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "Goldbeter1991SbmlOdeSystem.hpp").is_file()
+    assert not (tmp_path / "TestGoldbeter1991Sbml.hpp").exists()
+
+
+def test_generate_test_output_dir_routes_test(tmp_path):
+    """generate --test-output-dir places the placeholder test in its own directory."""
+    src_dir = tmp_path / "src"
+    test_dir = tmp_path / "test"
+    src_dir.mkdir()
+    test_dir.mkdir()
+
+    result = subprocess.run(
+        [
+            "chaste-sbml",
+            "generate",
+            str(GOLDBETER),
+            "--output-dir",
+            str(src_dir),
+            "--test-output-dir",
+            str(test_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (src_dir / "Goldbeter1991SbmlOdeSystem.hpp").is_file()
+    assert (test_dir / "TestGoldbeter1991Sbml.hpp").is_file()
+    assert not (src_dir / "TestGoldbeter1991Sbml.hpp").exists()

--- a/chaste_sbml/tests/test_test_generation.py
+++ b/chaste_sbml/tests/test_test_generation.py
@@ -40,6 +40,9 @@ def test_placeholder_test_generated(tmp_path, model_name, model_type, extra_clas
 
     code = model.test_outputs[test_filename]
 
+    # Every Chaste test must initialise PETSc; the placeholder is never run in parallel.
+    assert '#include "FakePetscSetup.hpp"' in code
+
     # The OdeSystem suite is always present and uses the lightweight CxxTest base class.
     assert f"class Test{model_name}SbmlOdeSystem : public CxxTest::TestSuite" in code
     assert "void TestOdeSystem()" in code

--- a/chaste_sbml/tests/test_test_generation.py
+++ b/chaste_sbml/tests/test_test_generation.py
@@ -1,0 +1,93 @@
+"""Tests for placeholder test-file generation."""
+
+import logging
+
+import pytest
+
+from chaste_sbml import ChasteSbmlModel
+from chaste_sbml._config import ROOT_DIR, ModelType
+
+logger = logging.getLogger(__name__)
+
+REFERENCE_DIR = ROOT_DIR / "SbmlRefModels" / "src" / "reference"
+
+
+def sbml_file(model_name: str) -> str:
+    """Path to a reference model's SBML input.
+
+    :param model_name: The reference model name e.g. "Goldbeter1991".
+    :return: Path to the SBML file.
+    """
+    return str(REFERENCE_DIR / model_name / f"{model_name}.xml")
+
+
+@pytest.mark.parametrize(
+    ("model_name", "model_type", "extra_class", "extra_method"),
+    [
+        ("Chen2000", ModelType.GENERIC, None, None),
+        ("Goldbeter1991", ModelType.SRN, "TestGoldbeter1991SbmlSrnModel", "TestSrnModel"),
+        ("Chen2000", ModelType.CELL_CYCLE, "TestChen2000SbmlCellCycleModel", "TestCellCycleModel"),
+    ],
+)
+def test_placeholder_test_generated(tmp_path, model_name, model_type, extra_class, extra_method):
+    """A placeholder test file is generated with an OdeSystem suite, plus an SRN/CellCycle suite."""
+    model = ChasteSbmlModel(sbml_file(model_name), model_type=model_type)
+    model.write(tmp_path)
+
+    test_filename = f"Test{model_name}Sbml.hpp"
+    assert test_filename in model.test_outputs
+    assert (tmp_path / test_filename).is_file()
+
+    code = model.test_outputs[test_filename]
+
+    # The OdeSystem suite is always present and uses the lightweight CxxTest base class.
+    assert f"class Test{model_name}SbmlOdeSystem : public CxxTest::TestSuite" in code
+    assert "void TestOdeSystem()" in code
+    assert f"TS_ASSERT_THROWS_NOTHING({model_name}SbmlOdeSystem ode_system);" in code
+
+    if extra_class is None:
+        # Generic models get only the OdeSystem suite -- no cell-based dependency.
+        assert "AbstractCellBasedTestSuite" not in code
+        assert "SrnModel" not in code
+        assert "CellCycleModel" not in code
+    else:
+        # SRN/CellCycle models get a separate cell-based suite for the extra role.
+        assert f"class {extra_class} : public AbstractCellBasedTestSuite" in code
+        assert f"void {extra_method}()" in code
+
+
+def test_no_tests_disables_generation(tmp_path):
+    """generate_tests=False produces no placeholder test, on disk or in memory."""
+    model = ChasteSbmlModel(sbml_file("Goldbeter1991"), model_type=ModelType.SRN, generate_tests=False)
+    model.write(tmp_path)
+
+    assert model.test_outputs == {}
+    written = {p.name for p in tmp_path.iterdir()}
+    assert "TestGoldbeter1991Sbml.hpp" not in written
+    # The model code is still generated.
+    assert "Goldbeter1991SbmlOdeSystem.hpp" in written
+
+
+def test_test_output_directory_routing(tmp_path):
+    """The placeholder test goes to test_output_directory, model code to output_directory."""
+    src_dir = tmp_path / "src"
+    test_dir = tmp_path / "test"
+    src_dir.mkdir()
+    test_dir.mkdir()
+
+    model = ChasteSbmlModel(sbml_file("Goldbeter1991"), model_type=ModelType.SRN)
+    model.write(src_dir, test_dir)
+
+    assert (test_dir / "TestGoldbeter1991Sbml.hpp").is_file()
+    assert not (src_dir / "TestGoldbeter1991Sbml.hpp").exists()
+    assert (src_dir / "Goldbeter1991SbmlOdeSystem.hpp").is_file()
+
+
+def test_test_defaults_to_output_directory(tmp_path):
+    """Without a test directory, the placeholder test lands next to the model code."""
+    model = ChasteSbmlModel(sbml_file("Goldbeter1991"), model_type=ModelType.SRN)
+    model.write(tmp_path)
+
+    written = {p.name for p in tmp_path.iterdir()}
+    assert "TestGoldbeter1991Sbml.hpp" in written
+    assert "Goldbeter1991SbmlOdeSystem.hpp" in written


### PR DESCRIPTION
Supports #37 

Emit a skeleton `Test<Model>Sbml.hpp` that the user can build up.

Add `--tests`/`--no-tests` and `--test-output-dir` to the generate command.